### PR TITLE
Properly destroy dropzone.js

### DIFF
--- a/src/index.vue
+++ b/src/index.vue
@@ -187,6 +187,10 @@
       this.dropzone.on('queuecomplete', function(file, xhr, formData){
         vm.$emit('vdropzone-queue-complete', file, xhr, formData)
       })
+    },
+
+    beforeDestroy () {
+      this.dropzone.destroy();
     }
   }
 


### PR DESCRIPTION
Dropzone.js creates hidden file inputs, which remain even after the component is destroyed.
![screenshot from 2017-03-01 19-38-49](https://cloud.githubusercontent.com/assets/11352152/23487834/b75e9c78-feb6-11e6-8162-74cd1c15332f.png)

A simple `.destroy()` call in the `beforeDestroy()` hook resolves this issue.
