### PR TITLE
Missing Event Listener in Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ Events emitted by the component to the parent.
 | vdropzone-sending(file, xhr, formData) | Modify the request and add addtional parameters to request before sending.|
 | vdropzone-success-multiple(files, response) | Fired if the uploadMultiple option is true.|
 | vdropzone-sending-multiple(files, xhr, formData) | Fired if the uploadMultiple option is true.|
+| vdropzone-queue-complete(file, xhr, formData) | Fired when complete queue has been processed/uploaded.|
+
 
 
 ## Development


### PR DESCRIPTION
Added docs for `vdropzone-queue-complete` event listener.