### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You'll also need to load either the [Material Icon](https://material.io/icons/) 
 ````
 
 ## Usage
-1. Import the module
+1. Import the module (`import Dropzone from 'vue2-dropzone') 
 2. Register it as a component as you would any other Vue component
 3. Use it within your template
 


### PR DESCRIPTION
Hi, I got a little confused first seeing the name of the repository (`vue-dropzone`) and then reading the installation step:

1. Import the module

Vue CLI told me that the package is not present and that I can install it using `npm install vue-dropzone --save`

Fortunately I ran your installation command before (`npm install vue2-dropzone --save`) and so things seemed weird to me. Then I realized I was importing `vue-dropzone`, which is probably an older package, which I have figured out later in the example.

Just a little clarification to the README.

Thanks for the wonderful job!