### PR TITLE
Options parameters for changing some ways how maxFiles and files.length after using manuallyAddFile method works

### DIFF
--- a/src/index.vue
+++ b/src/index.vue
@@ -122,11 +122,14 @@
                 this.dropzone.emit("addedfile", file);
                 this.dropzone.emit("thumbnail", file, fileUrl);
                 this.dropzone.createThumbnailFromUrl(file, fileUrl, callback, crossOrigin);
-                this.dropzone.emit("complete", file);
-                this.$emit('vdropzone-file-added-manually', file);
+                this.dropzone.emit("complete", file);                
                 if ((typeof options.dontSubstractMaxFiles == 'undefined') || !options.dontSubstractMaxFiles) {
                     this.dropzone.options['maxFiles'] = this.dropzone.options['maxFiles'] - 1;
                 }
+                if ((typeof options.addToFiles != 'undefined') && options.addToFiles) {
+                    this.dropzone.files.push(file);
+                }
+                this.$emit('vdropzone-file-added-manually', file);
             },
             setOption: function (option, value) {
                 this.dropzone.options[option] = value

--- a/src/index.vue
+++ b/src/index.vue
@@ -118,13 +118,15 @@
             }
         },
         methods: {
-            manuallyAddFile: function (file, fileUrl, callback, crossOrigin) {
+            manuallyAddFile: function (file, fileUrl, callback, crossOrigin, options) {
                 this.dropzone.emit("addedfile", file);
                 this.dropzone.emit("thumbnail", file, fileUrl);
                 this.dropzone.createThumbnailFromUrl(file, fileUrl, callback, crossOrigin);
                 this.dropzone.emit("complete", file);
                 this.$emit('vdropzone-file-added-manually', file);
-                this.dropzone.options['maxFiles'] = this.dropzone.options['maxFiles'] - 1;
+                if ((typeof options.dontSubstractMaxFiles == 'undefined') || !options.dontSubstractMaxFiles) {
+                    this.dropzone.options['maxFiles'] = this.dropzone.options['maxFiles'] - 1;
+                }
             },
             setOption: function (option, value) {
                 this.dropzone.options[option] = value


### PR DESCRIPTION
`manuallyAddFile` method now has 5th parameter - options. I added this one because to keep backward compatibility. Old code will not use this parameter, but all new code can use and add some new functionality.

Currently options can have two params:
 * `dontSubstractMaxFiles` - if is `true`, will not execute `this.dropzone.options['maxFiles'] = this.dropzone.options['maxFiles'] - 1` line; This is because such functionality not always is needed.
 *  `addToFiles ` - if is `true`, adds manually added file also to files array. This is needed when using code that counts files. 

I think this can solve #123 and similar issues with this library.