### PR TITLE
Destroy dropzone when destroying the component.

### DIFF
--- a/src/index.vue
+++ b/src/index.vue
@@ -347,7 +347,7 @@
             vm.$emit('vdropzone-mounted');
         },
         beforeDestroy () {
-            this.dropzone.disable();
+            this.dropzone.destroy();
         }
     }
 </script>


### PR DESCRIPTION
Restore #45 reverted in 2bb9358d20be44ceca9781b3e9c439c72ca2b09b.

This should fix #117.