### PR TITLE
csrf token example for Laravel Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,31 @@ mounted () {
 }
 ```
 
+## Integration with Laravel Framework
+In order to use vue-dropzone with laravel, you need to add the csrf-token to the component. Note that you need 2 things for it to work with Laravel:
+ 
+1. A hidden input with name="csrf-token" and :value that can be set in data() of your component.
+2.Additionally, you need to set :headers attribute for dropzone component where you pass a csrfHeader object created under the data() function in your vue component. See below for example:
+ 
+```html
+    <dropzone id="myVueDropzone" url="https://httpbin.org/post" v-on:vdropzone-success="showSuccess"
+    :headers="csrfHeader">
+        <!-- csrf token for laravel -->
+        <input type="hidden" name="csrf-token" :value="csrfToken">
+    </dropzone>
+```
+ 
+```html
+  data() {
+    return {
+      csrfToken: document.head.querySelector('meta[name="csrf-token"]').content,
+            csrfHeader: {
+                'X-CSRF-TOKEN': document.head.querySelector('meta[name="csrf-token"]').content
+            }
+    }
+  }
+```
+
 ## Development
 
 ``` bash

--- a/README.md
+++ b/README.md
@@ -162,17 +162,23 @@ mounted () {
 
 ## Integration with Laravel Framework
 In order to use vue-dropzone with laravel, you need to add the csrf-token to the component. Note that you need 2 things for it to work with Laravel:
- 
+
 1. A hidden input with name="csrf-token" and :value that can be set in data() of your component.
 
-2.Additionally, you need to set :headers attribute for dropzone component where you pass a csrfHeader object created under the data() function in your vue component. See below for example:
+2. Additionally, you need to set :headers attribute for dropzone component where you pass a csrfHeader object created under the data() function in your vue component. See below for example:
  
 ```html
-    <dropzone id="myVueDropzone" url="https://httpbin.org/post" v-on:vdropzone-success="showSuccess"
-    :headers="csrfHeader">
+<template>
+    <div>
+        <dropzone id="myVueDropzone"
+                  url="/post"
+                  v-on:vdropzone-success="showSuccess"
+                  :headers="csrfHeader">
         <!-- csrf token for laravel -->
         <input type="hidden" name="csrf-token" :value="csrfToken">
-    </dropzone>
+        </dropzone>
+    </div>
+</template>
 ```
  
 ```html

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ mounted () {
 In order to use vue-dropzone with laravel, you need to add the csrf-token to the component. Note that you need 2 things for it to work with Laravel:
  
 1. A hidden input with name="csrf-token" and :value that can be set in data() of your component.
+
 2.Additionally, you need to set :headers attribute for dropzone component where you pass a csrfHeader object created under the data() function in your vue component. See below for example:
  
 ```html
@@ -175,14 +176,19 @@ In order to use vue-dropzone with laravel, you need to add the csrf-token to the
 ```
  
 ```html
-  data() {
-    return {
-      csrfToken: document.head.querySelector('meta[name="csrf-token"]').content,
+
+<script>
+export default {
+    data() {
+        return {
+            csrfToken: document.head.querySelector('meta[name="csrf-token"]').content,
             csrfHeader: {
                 'X-CSRF-TOKEN': document.head.querySelector('meta[name="csrf-token"]').content
             }
     }
   }
+}
+</script>
 ```
 
 ## Development


### PR DESCRIPTION
To use vue-dropzone with laravel, we need to add csrf token to it and this example helps with that.