### PR TITLE
Added 'withCredentials' option override

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Many of these props are inherited from [dropzone configuration so see their doco
 | capture | String | If `null`, no capture type will be specified If `camera`, mobile devices will skip the file selection and choose camera If `microphone`, mobile devices will skip the file selection and choose the microphone If `camcorder`, mobile devices will skip the file selection and choose the camera in `video` mode On apple devices multiple must be set to false. AcceptedFiles may need to be set to an appropriate mime type `(e.g. "image/", "audio/", or "video/*")`. `Default:null` |
 | hiddenInputContainer | String | Element the hidden input field will be appended to. This might be important in case you use frameworks to switch the content of your page. `Default:body`|
 | confirm | Function | A function for overriding native confirmation dialog box of browser. `Parameters: question, accepted, rejected`|
-
+| withCredentials | Boolean | Whether or not cross-site Access-Control requests should be made using credentials such as cookies, authorization headers or TLS client certificates. `Default:false`|
 
 ## Custom Dropzone preview template
 

--- a/src/index.vue
+++ b/src/index.vue
@@ -135,6 +135,10 @@
             method:{
                 type : String,
                 default : 'POST'
+            },
+            withCredentials: {
+                type : Boolean,
+                default : false
             }
         },
         methods: {
@@ -288,7 +292,8 @@
                 timeout                     : this.getProp(this.timeout, this.dropzoneOptions.timeout),
                 method                      : this.getProp(this.method, this.dropzoneOptions.method),
                 capture                     : this.getProp(this.method, this.dropzoneOptions.method),
-                hiddenInputContainer        : this.getProp(this.method, this.dropzoneOptions.method) 
+                hiddenInputContainer        : this.getProp(this.method, this.dropzoneOptions.method),
+                withCredentials             : this.getProp(this.withCredentials, this.dropzoneOptions.withCredentials)
             })
 
             // Handle the dropzone events


### PR DESCRIPTION
I was missing the option to pass a cookie to Dropzone, so I added this PR