### PR TITLE
Added missing dataUrl to the thumbnail event as second parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Events emitted by the component to the parent.
 | vdropzone-file-added(file) | File added to the dropzone.|
 | vdropzone-files-added(file) | Files added to the dropzone.|
 | vdropzone-file-added-manually(file) | Manually added file to the dropzone |
+| vdropzone-thumbnail(file, dataUrl) | When the thumbnail has been generated. Receives the dataUrl as second parameter. |
 | vdropzone-success(file, response) | File successfully uploaded.|
 | vdropzone-error(file) | File uploaded encountered an error.|
 | vdropzone-removed-file(file, error, xhr) | A file was removed from the dropzone.|

--- a/src/index.vue
+++ b/src/index.vue
@@ -299,8 +299,8 @@
             // Handle the dropzone events
             let vm = this;
 
-            this.dropzone.on('thumbnail', function (file) {
-                vm.$emit('vdropzone-thumbnail', file)
+            this.dropzone.on('thumbnail', function (file, dataUrl) {
+                vm.$emit('vdropzone-thumbnail', file, dataUrl)
             });
 
             this.dropzone.on('addedfile', function (file) {


### PR DESCRIPTION
Hi, I have added a missing parameter for thumbnail event.

When are you planning on releasing next time?, because i need this second parameter to make a proper previewTemplate..

Also I was not able to test the code though `npm run build` when loading the page i get this error `Cannot read property 'appendChild' of null`, this error was there before i did my changes. I did doe test the changes though the compiled file provided though the npm package