### PR TITLE
Edit/Improve doc link added to each page

### DIFF
--- a/docs/src/App.vue
+++ b/docs/src/App.vue
@@ -46,4 +46,25 @@ export default {
     line-height: 1.3rem;
     margin: 0.5em 0;
   }
+
+.float{
+  position:fixed;
+  width:auto;
+  height:30px;
+  top:50px;
+  right:64px;
+  padding: 5px 20px;
+  border-radius: 4px;
+}
+a.float.doc-link{
+  color: #aaa;
+  border: dashed 1px #aaa;
+  /*background: #314B5F;*/
+  text-decoration: none;
+  text-transform: uppercase;
+}
+a.float:hover{
+  color:#42b983;
+  border: dashed 1px #42b983;
+}
 </style>

--- a/docs/src/components/DocEditLink.vue
+++ b/docs/src/components/DocEditLink.vue
@@ -1,0 +1,27 @@
+<template>
+	<div>
+		<a href="#" class="float doc-link" :href="url" target="_blank" v-if="link">
+        	Edit this Doc
+    </a>
+	</div>
+</template>
+<script>
+import docConfig from '../config/docConfig';
+	export default{
+		props: {
+    		link: {
+      			type: String,
+      			required: false,
+      			defaut:"#"
+    		}
+    	},
+      mounted(){
+        console.log(docConfig.branch)
+      },
+      computed:{
+        url(){
+          return docConfig.repository + "/blob/" + docConfig.branch + "/" + docConfig.docSource + "/" + this.link;
+        }
+      }
+	}
+</script>

--- a/docs/src/config/docConfig.js
+++ b/docs/src/config/docConfig.js
@@ -1,0 +1,5 @@
+export default{
+	'repository': 'https://github.com/rowanwins/vue-dropzone',
+	'branch': 'version3',
+	'docSource': 'docs/src/pages'
+}

--- a/docs/src/pages/AddingIconDemo.vue
+++ b/docs/src/pages/AddingIconDemo.vue
@@ -8,13 +8,14 @@
     </vue-dropzone>
     <h3>Snippet</h3>
     <p v-html="marked(example)"></p>
+    <edit-doc :link="'AddingIconDemo.vue'"></edit-doc>
   </div>
 
 </template>
 
 <script>
 import { vueDropzone } from '../../../src/';
-
+import editDoc from '../components/DocEditLink.vue';
 var example = `
   @import url("https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css");
 
@@ -42,7 +43,8 @@ export default {
       }
   },
   components: {
-    vueDropzone
+    vueDropzone,
+    'edit-doc' : editDoc
   }
 }
 </script>

--- a/docs/src/pages/Events.vue
+++ b/docs/src/pages/Events.vue
@@ -5,11 +5,13 @@
     <simple-table
       :headers="['Event Name', 'Description']" 
       :rows="events" />
+      <edit-doc :link="'Events.vue'"></edit-doc>
   </div>
 </template>
 
 <script>
 import SimpleTable from '../components/SimpleTable.vue';
+import editDoc from '../components/DocEditLink.vue';
 
 export default {
   data: function () {
@@ -51,7 +53,8 @@ export default {
     }
   },
   components: {
-    'simple-table': SimpleTable
+    'simple-table': SimpleTable,
+    'edit-doc': editDoc
   }  
 }
 </script>

--- a/docs/src/pages/Installation.vue
+++ b/docs/src/pages/Installation.vue
@@ -13,8 +13,18 @@
 cd vue-dropzone
 npm install
 npm run build</code></pre>
+<edit-doc :link="'Installation.vue'"></edit-doc>
   </div>
 </template>
+<script>
+  import editDoc from '../components/DocEditLink.vue';
+  
+  export default{
+    components:{
+      'edit-doc': editDoc
+    }
+  }
+</script>
 <style>
 	.center-c{
 		display: flex;

--- a/docs/src/pages/ManuallyAddDemo.vue
+++ b/docs/src/pages/ManuallyAddDemo.vue
@@ -14,12 +14,14 @@
     <button v-on:click="addFile">Manually add file</button>
     <h3>Snippet</h3>
     <p v-html="marked(example)"></p>
+    <edit-doc :link="'ManuallyAddDemo.vue'"></edit-doc>
   </div>
 
 </template>
 
 <script>
 import { vueDropzone } from '../../../src/';
+import editDoc from '../components/DocEditLink.vue';
 
 var example = `
   <vue-dropzone ref="myVueDropzone">
@@ -56,7 +58,8 @@ export default {
     }
   },
   components: {
-    vueDropzone
+    vueDropzone,
+    'edit-doc' : editDoc
   }
 }
 </script>

--- a/docs/src/pages/Methods.vue
+++ b/docs/src/pages/Methods.vue
@@ -7,12 +7,14 @@
       :rows="methods" />
     <h3>Snippet</h3>
     <p v-html="marked(example)"></p>
-
+    <edit-doc :link="'Methods.vue'"></edit-doc>
   </div>
 </template>
 
 <script>
 import SimpleTable from '../components/SimpleTable.vue';
+import editDoc from '../components/DocEditLink.vue';
+
 var example = `
   <vue-dropzone ref="myVueDropzone">
   ....
@@ -43,7 +45,8 @@ export default {
     }
   },
   components: {
-    'simple-table': SimpleTable
+    'simple-table': SimpleTable,
+    'edit-doc': editDoc
   }  
 }
 </script>

--- a/docs/src/pages/Props.vue
+++ b/docs/src/pages/Props.vue
@@ -5,11 +5,13 @@
     <simple-table
       :headers="['Prop Name', 'Type', 'Description', 'Required']" 
       :rows="props" />
+      <edit-doc :link="'Props.vue'"></edit-doc>
   </div>
 </template>
 
 <script>
 import SimpleTable from '../components/SimpleTable.vue';
+import editDoc from '../components/DocEditLink.vue';
 
 export default {
   data: function () {
@@ -23,7 +25,8 @@ export default {
     }
   },
   components: {
-    'simple-table': SimpleTable
+    'simple-table': SimpleTable,
+    'edit-doc': editDoc
   }  
 }
 </script>

--- a/docs/src/pages/SendAdditionalParamsDemo.vue
+++ b/docs/src/pages/SendAdditionalParamsDemo.vue
@@ -9,11 +9,13 @@
     </vue-dropzone>
     <h3>Snippet</h3>
     <p v-html="marked(example)"></p>
+    <edit-doc :link="'SendAdditionalParamsDemo.vue'"></edit-doc>
   </div>
 </template>
 
 <script>
 import { vueDropzone } from '../../../src/';
+import editDoc from '../components/DocEditLink.vue';
 
 var example = `
   <vue-dropzone v-on:vdropzone-sending="sendingEvent">
@@ -42,7 +44,8 @@ export default {
     }
   },
   components: {
-    vueDropzone
+    vueDropzone,
+    'edit-doc': editDoc 
   }
 }
 </script>

--- a/docs/src/pages/SlotsDemo.vue
+++ b/docs/src/pages/SlotsDemo.vue
@@ -9,12 +9,14 @@
     </vue-dropzone>
     <h3>Snippet</h3>
     <p v-html="marked(example)"></p>
+    <edit-doc :link="'SlotsDemo.vue'"></edit-doc>
   </div>
 
 </template>
 
 <script>
 import { vueDropzone } from '../../../src/';
+import editDoc from '../components/DocEditLink.vue';
 
 var example = `
   <vue-dropzone :options="dropzoneOptions">
@@ -147,7 +149,8 @@ export default {
       }
   },
   components: {
-    vueDropzone
+    vueDropzone,
+    'edit-doc': editDoc
   },
   methods:{
     'template':function() {

--- a/docs/src/pages/UploadToAWSS3.vue
+++ b/docs/src/pages/UploadToAWSS3.vue
@@ -11,7 +11,7 @@
       :options="dropzoneOptions">
     </vue-dropzone>
     <hr>
-    <label>Enter your URL Signer Endpoint</label><br>
+    <label>Enter your URL Signer Endpoint</label> <span class="note">(POST request will be sent to endpoint)</span><br>
     <input type="text" v-model="signurl" ref="urlsigner" placeholder="http://mydomain.com/" required="">
     <button @click="uploadFiles">Upload Files</button>
     <h3>Response of your URL Signer should be as below</h3>
@@ -38,11 +38,13 @@
     <div v-html="marked(awsNote)"></div>
     <h3>Snippet</h3>
     <p v-html="marked(example)"></p>
+    <edit-doc :link="'UploadToAWSS3.vue'"></edit-doc>
   </div>
 </template>
 
 <script>
 import { vueDropzone } from '../../../src/';
+import editDoc from '../components/DocEditLink.vue';
 
 var example = `
   <vue-dropzone 
@@ -110,7 +112,8 @@ export default {
     }
   },
   components: {
-    vueDropzone
+    vueDropzone,
+    'edit-doc': editDoc
   }
 }
 </script>
@@ -123,5 +126,8 @@ input[type=text] {
 }
 label{
   font-weight: bold;
+}
+.note{
+  color: red;
 }
 </style>

--- a/docs/src/pages/demo.vue
+++ b/docs/src/pages/demo.vue
@@ -119,12 +119,14 @@
         </tr>
       </tbody>
   </table>
+  <edit-doc :link="'demo.vue'"></edit-doc>
   </div>
 
 </template>
 
 <script>
 import { vueDropzone } from '../../../src/';
+import editDoc from '../components/DocEditLink.vue';
 
 export default {
   data () {
@@ -164,7 +166,8 @@ export default {
       }
   },
   components: {
-    vueDropzone
+    vueDropzone,
+    'edit-doc' : editDoc
   },
   methods: {
     vfileAdded (file) {

--- a/src/docLinks.js
+++ b/src/docLinks.js
@@ -1,7 +1,0 @@
-export default{
-	return {
-		'repository': '',
-		'branch': '',
-		'docSource': ''
-	}
-}

--- a/src/docLinks.js
+++ b/src/docLinks.js
@@ -1,0 +1,7 @@
+export default{
+	return {
+		'repository': '',
+		'branch': '',
+		'docSource': ''
+	}
+}


### PR DESCRIPTION
### Changelog
- Added button on each page which will be shown ~as demo~ (bad typos)  to users, from where they will be redirected to respective demo page on github.
    - `branch name`, `repo name`, `docs source in repo` are defined in separate file, using computed properties complete url is retrieved. The only thing user needs to add while createing new page is adding `page name` to component `<edit-doc>` component.

---

### Intention behind creating this PR

Some times there some improvements/typos etc. in docs. If user wants to suggest update for that particular file/component/demopage  then he can just click the button and he will be served with a file which he want to update. User can effectively send the patch for that file.

Else what happens user is not familiar with base structure of project and he has to figure out and then send the patch.

@rowanwins @AlexanderYW Please share your thoughts.

@rowanwins If you found this PR useful you can merge it after review.