### PR TITLE
Use all properties, including the key, from the URL signer.

### DIFF
--- a/src/services/urlsigner.js
+++ b/src/services/urlsigner.js
@@ -28,13 +28,7 @@ export default {
       .then((response) => {
         let signature = response.signature;
         Object.keys(signature).forEach(function (key) {
-          if (key == 'key') {
-            fd.append('key', file.name);
-          } else if (key == 'Content-Type') {
-            fd.append("Content-Type", file.type);
-          } else {
-            fd.append(key, signature[key]);
-          }
+          fd.append(key, signature[key]);
         });
         fd.append('file', file);
         return new Promise((resolve, reject) => {


### PR DESCRIPTION
Forces all properties from the URL signer to be set.