### PR TITLE
AWS fixes

### DIFF
--- a/src/services/urlsigner.js
+++ b/src/services/urlsigner.js
@@ -20,10 +20,13 @@ export default {
         console.error("Network Error : Could not send request to AWS (Maybe CORS errors)");
         reject(err)
       };
-      Object.entries(config.headers).forEach(([name, value]) => {
+      Object.entries(config.headers || {}).forEach(([name, value]) => {
         request.setRequestHeader(name, value);
       });
-      Object.entries(config.params).forEach(([name, value]) => {
+      Object.entries(payload).forEach(([name, value]) => {
+        fd.append(name, value);
+      });
+      Object.entries(config.params || {}).forEach(([name, value]) => {
         fd.append(name, value);
       });
 


### PR DESCRIPTION
* Send contentType and filePath in request to s3 signing URL -- currently these are omitted -- only awss3.params are sent

* Don't require params and headers objects in awss3 config -- currently results in a confusing "Network Error : Could not send request to AWS. (Maybe CORS error)" error before any network requests are made because e.g. `Object.entries(config.params)` throws an exception if config.params is undefined