### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,6 @@
     "dist"
   ],
   "dependencies": {
-    "dropzone": "^5.4.0"
+    "dropzone": "^5.5.0"
   }
 }


### PR DESCRIPTION
Changed version for dropzone to 5.5.0, as 5.4.0 tag has been erased.