### PR TITLE
Fix sidebar logo link

### DIFF
--- a/docs/src/sections/SideBar.vue
+++ b/docs/src/sections/SideBar.vue
@@ -1,7 +1,7 @@
 <template>
   <aside class="sidebar">
     <h1>
-      <a class="app-name-link" data-nosearch="" href="/"><img src="../assets/vue2-dropzone1.png"></a>
+      <a class="app-name-link" data-nosearch="" href="/vue-dropzone/docs/"><img src="../assets/vue2-dropzone1.png"></a>
     </h1>
 
     <hr class="border">


### PR DESCRIPTION
Currently, it redirects me to `rowanwins.github.io` which isn't part of the docs. I think a lot of people also click on the logo to go to the _homepage_.