### PR TITLE
Add MIT license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "Alexander Wennerstrøm <@AlexanderYW>"
   ],
   "version": "3.5.8",
+  "license": "MIT",
   "main": "./dist/vue2Dropzone.js",
   "repository": "git@github.com:rowanwins/vue-dropzone.git",
   "devDependencies": {


### PR DESCRIPTION
Having this will make the license that you already have in the git repository show up on npmjs.com