### PR TITLE
Documentation for prop naming (non-breaking)

### DIFF
--- a/docs/src/pages/Props.vue
+++ b/docs/src/pages/Props.vue
@@ -17,11 +17,11 @@ export default {
       props: [
         ['id', 'String','dropzone', 'A string by which to identify the component, can be anything', 'True'],
         ['options', 'Object','{}', 'A dropzone [configuration object](http://www.dropzonejs.com/#configuration-options), accepts all valid dropzone configuration', 'True'],
-        ['includeStyling', 'Boolean','True', 'Whether to include the dropzone and component styling.', 'False'],
+        ['include-styling', 'Boolean','True', 'Whether to include the dropzone and component styling.', 'False'],
         ['awss3', 'Object','{}', 'Object consisting of 3 values signingURL, headers, and params. You can use the headers and params keys to send additional headers or parameters with the signing request (e.g. CSRF tokens). See [Demo and config](#/aws-s3-upload)', 'False'],
-        ['destroyDropzone', 'Boolean','True', 'Destroy the dropzone object when the component is destroyed.', 'False'],
-        ['duplicateCheck','Boolean','False','Check if added file is duplicate, in already dropped files in dropzone','False'],
-        ['useCustomSlot','Boolean','False','Use a custom slot for the default message area','False'],
+        ['destroy-dropzone', 'Boolean','True', 'Destroy the dropzone object when the component is destroyed.', 'False'],
+        ['duplicate-check','Boolean','False','Check if added file is duplicate, in already dropped files in dropzone','False'],
+        ['use-custom-slot','Boolean','False','Use a custom slot for the default message area','False'],
       ]
     }
   },


### PR DESCRIPTION
Warnings appear with vue 2.0 in inspection: (when doing :useCustomSlot="true")

[Vue tip]: Prop "usecustomslot" is passed to component <Anonymous>, but the declared prop name is "useCustomSlot". Note that HTML attributes are case-insensitive and camelCased props need to use their kebab-case equivalents when using in-DOM templates. You should probably use "use-custom-slot" instead of "useCustomSlot".

Updating documentation to help others, avoid warning messages.