### PR TITLE
Updating s3 xml response message parsing

### DIFF
--- a/src/services/urlsigner.js
+++ b/src/services/urlsigner.js
@@ -59,8 +59,8 @@ export default {
       request.open('POST', response.postEndpoint);
       request.onload = function () {
         if (request.status == 201) {
-          var s3Error = (new window.DOMParser()).parseFromString(request.response, "text/xml");
-          var successMsg = s3Error.firstChild.children[0].innerHTML;
+          var s3Success = (new window.DOMParser()).parseFromString(request.response, "text/xml");
+          var successMsg = s3Success.getElementsByTagName('PostResponse')[0].getElementsByTagName('Location')[0].innerHTML;
           resolve({
             'success': true,
             'message': successMsg
@@ -76,7 +76,7 @@ export default {
       };
       request.onerror = function (err) {
         var s3Error = (new window.DOMParser()).parseFromString(request.response, "text/xml");
-        var errMsg = s3Error.firstChild.children[1].innerHTML;
+        var errMsg = s3Error.getElementsByTagName('Error')[0].getElementsByTagName('Message')[0].innerHTML;
         reject({
           'success': false,
           'message': errMsg


### PR DESCRIPTION
Updating s3 XML response message parsing in order to allow unordered responses while still returning the correct s3ObjectLocation value.

Currently the first child of the first element is assumed to be the location of the s3 object. The s3 alternative [Minio](https://min.io/) does have the same elements, but not in the same order. 
In order to support both [Minio](https://min.io/) and potential future changes in the s3 response a more targeted approach is suggested in this pull request.

Parsing changes based on:
  - [https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPOST.html#RESTObjectPOST-requests-responses-response-elements](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPOST.html#RESTObjectPOST-requests-responses-response-elements)
  - [https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html](https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html)

C&c very welcome.