### PR TITLE
DONT MERGE Renaming removed file event for consistency

### DIFF
--- a/src/components/vue-dropzone.vue
+++ b/src/components/vue-dropzone.vue
@@ -133,7 +133,7 @@ export default {
     });
 
     this.dropzone.on("removedfile", function(file) {
-      vm.$emit("vdropzone-removed-file", file);
+      vm.$emit("vdropzone-file-removed", file);
       if (file.manuallyAdded && vm.dropzone.options.maxFiles !== null)
         vm.dropzone.options.maxFiles++;
     });


### PR DESCRIPTION
Found that for removing file event, the event naming consistency wasn't followed :
`vdropzone-file-added` or `vdropzone-files-added` for example
versus
`vdropzone-removed-file`