### PR TITLE
Update styles for small uploaded images

### DIFF
--- a/src/components/vue-dropzone.vue
+++ b/src/components/vue-dropzone.vue
@@ -447,6 +447,15 @@ export default {
   color: #ccc;
 }
 
+.vue-dropzone > .dz-preview {
+  min-height: 150px;
+  min-width: 150px;
+}
+
+.dropzone > .dz-preview.dz-image-preview {
+  background-color: #efefef;
+}
+
 .vue-dropzone > .dz-preview .dz-image {
   border-radius: 0;
   width: 100%;
@@ -456,6 +465,9 @@ export default {
 .vue-dropzone > .dz-preview .dz-image img:not([src]) {
   width: 200px;
   height: 200px;
+}
+.vue-dropzone > .dz-preview .dz-image img {
+  margin: 0 auto;
 }
 
 .vue-dropzone > .dz-preview .dz-image:hover img {


### PR DESCRIPTION
I've noticed styling issues when small images are uploaded. On hover the text is illegible and overall not user friendly like so:

![Screen Shot 2019-10-03 at 9 47 38 PM](https://user-images.githubusercontent.com/10490094/66179878-df8a3300-e627-11e9-8569-3d046a64e0e1.png)
![Screen Shot 2019-10-03 at 9 47 44 PM](https://user-images.githubusercontent.com/10490094/66179877-df8a3300-e627-11e9-9b27-1d81e372555c.png)

I've improved the styling around `dz-preview` to accomodate small image uploads, fixed the sizing and added background like so:

![Screen Shot 2019-10-03 at 9 46 48 PM](https://user-images.githubusercontent.com/10490094/66179949-2710bf00-e628-11e9-932c-0fde0ab2fdb1.png)
![Screen Shot 2019-10-03 at 9 46 41 PM](https://user-images.githubusercontent.com/10490094/66179951-2710bf00-e628-11e9-8194-76f83efe7a2d.png)
