### PR TITLE
TypeError: this.files[t].lastModifiedDate is undefined

### DIFF
--- a/src/components/vue-dropzone.vue
+++ b/src/components/vue-dropzone.vue
@@ -111,8 +111,7 @@ export default {
             if (
               this.files[_i].name === file.name &&
               this.files[_i].size === file.size &&
-              this.files[_i].lastModifiedDate.toString() ===
-                file.lastModifiedDate.toString()
+              this.files[_i].lastModified === file.lastModified
             ) {
               this.removeFile(file);
               isDuplicate = true;


### PR DESCRIPTION
In Safari file object doesn't have `lastModifiedDate` property. Use `lastModified` timestamp instead when detecting a duplicate image upload.

Solves issue #482 