### PR TITLE
added src directory  in package.json and import dropzone.css path changed for babel transpile based on user config

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "start": "cross-env NODE_ENV=development webpack-dev-server --mode development --open --hot"
   },
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "dependencies": {
     "dropzone": "^5.5.1"

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import './../node_modules/dropzone/dist/dropzone.css'
+import 'dropzone/dist/dropzone.css'
 import vueDropzone from './components/vue-dropzone.vue'
 
 export default vueDropzone


### PR DESCRIPTION
exposing because it allows user build config to take over instead of relying on already built file.
This resolved IE11 unexpected ':' since my build pipeline is set for ie 11 (i am using nuxt js and same goes for vue cli => set transpiledep in config.js file)