### PR TITLE
Update link to dropzone configuration object

### DIFF
--- a/docs/src/pages/Props.vue
+++ b/docs/src/pages/Props.vue
@@ -16,7 +16,7 @@ export default {
     return {
       props: [
         ['id', 'String','dropzone', 'A string by which to identify the component, can be anything', 'True'],
-        ['options', 'Object','{}', 'A dropzone [configuration object](http://www.dropzonejs.com/#configuration-options), accepts all valid dropzone configuration', 'True'],
+        ['options', 'Object','{}', 'A dropzone [configuration object](https://docs.dropzone.dev/configuration/basics/configuration-options), accepts all valid dropzone configuration', 'True'],
         ['include-styling', 'Boolean','True', 'Whether to include the dropzone and component styling.', 'False'],
         ['awss3', 'Object','{}', 'Object consisting of 3 values signingURL, headers, and params. You can use the headers and params keys to send additional headers or parameters with the signing request (e.g. CSRF tokens). See [Demo and config](#/aws-s3-upload)', 'False'],
         ['destroy-dropzone', 'Boolean','True', 'Destroy the dropzone object when the component is destroyed.', 'False'],


### PR DESCRIPTION
URL seems to have changed, current path leads you to the landing page, not the docs